### PR TITLE
PWM Driver Fix

### DIFF
--- a/doc/pwm_driver.rst
+++ b/doc/pwm_driver.rst
@@ -34,34 +34,6 @@ Pin Configuration
 
    :param module: CCP module number (1-4).
 
-.. c:macro:: GET_TRIS_REG(port)
-
-   Retrieves the TRIS register for the specified port.
-
-   :param port: Port letter (A, B, C).
-
-.. c:macro:: GET_PPS_REG(port, pin)
-
-   Retrieves the PPS register address for the specified port and pin.
-
-   :param port: Port letter (A, B, C).
-   :param pin: Pin number (0-7).
-
-.. c:macro:: SET_TRIS_OUTPUT(port, pin)
-
-   Sets the specified pin as output by modifying the TRIS register.
-
-   :param port: Port letter (A, B, C).
-   :param pin: Pin number (0-7).
-
-.. c:macro:: ASSIGN_PPS(port, pin, ccp_module)
-
-   Assigns the CCP module to the specified PPS register to map the peripheral to the desired pin.
-
-   :param port: Port letter (A, B, C).
-   :param pin: Pin number (0-7).
-   :param ccp_module: CCP module number (1-4).
-
 CCP Mode Configuration
 ----------------------
 .. c:macro:: CONFIGURE_CCP_MODE(ccp_module, ccp_con)
@@ -98,9 +70,9 @@ PWM Pin Configuration Structure
 
    Structure that holds the configuration details for a PWM pin.
 
-   :param port: Port letter (A, B, C).
+   :param tris_reg: Pointer to the TRIS register for the pin (e.g., &TRISA).
+   :param pps_reg: Pointer to the PPS register for the pin (e.g., &RA0PPS).
    :param pin: Pin number (0-7).
-   :param pps_reg: PPS register value for this pin.
 
 Initialization
 --------------
@@ -109,7 +81,7 @@ Initialization
    Initializes PWM for the specified CCP module with the given pin configuration and PWM period.
 
    :param ccp_module: CCP module number (1-4).
-   :param pin_config: PWM pin configuration structure containing port, pin, and PPS register values.
+   :param pin_config: PWM pin configuration structure containing TRIS and PPS register pointers, and pin number.
    :param pwm_period: PWM period value.
    :return: W_SUCCESS on successful initialization, otherwise an error code.
 
@@ -146,7 +118,7 @@ PPS Configuration
    Configures Peripheral Pin Select (PPS) for the specified pin and CCP module. This function is essential for routing the PWM signal to the correct output pin.
 
    :param ccp_module: CCP module number (1-4).
-   :param pin_config: Structure containing port, pin, and PPS register values.
+   :param pin_config: Structure containing TRIS and PPS register pointers, and pin number.
    :return: W_SUCCESS if successful, W_INVALID_PARAM if the module number is out of range.
 
 Error Handling
@@ -162,3 +134,32 @@ Practical Considerations
 - **Timer Usage**: Ensure Timer 2 is not shared with other peripherals to avoid conflicts in PWM generation.
 - **Prescaler and Postscaler**: The prescaler and postscaler are currently set to 1:1 for simplicity. These can be adjusted to modify the frequency of the PWM signal.
 - **Pin Mapping**: Correct pin mapping is critical for proper operation. Incorrect configuration can result in no output or conflicts with other peripherals.
+
+Usage Example
+============
+
+.. code-block:: c
+
+   #include "pwm.h"
+   #include <xc.h>
+
+   void setup_pwm(void) {
+       // Create PWM configuration for pin RA0
+       pwm_pin_config_t pwm_config;
+       pwm_config.tris_reg = &TRISA;    // Direct pointer to TRIS register
+       pwm_config.pps_reg = &RA0PPS;    // Direct pointer to PPS register
+       pwm_config.pin = 0;              // Pin number (RA0)
+
+       // Initialize PWM on CCP1 module with period of 255
+       pwm_init(1, pwm_config, 255);
+
+       // Set initial duty cycle to 50%
+       pwm_update_duty_cycle(1, 512);   // 512 is ~50% of 1023 (10-bit resolution)
+   }
+
+Notes
+-----
+- Using direct register pointers provides better type safety and avoids compile-time macro issues
+- The TRIS register controls pin direction (input/output)
+- The PPS register controls peripheral pin select routing
+- Register pointers must be valid 

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -6,9 +6,9 @@
 
 // Structure to hold the configuration details for a PWM pin
 typedef struct {
-    uint8_t port; // Port letter (A, B, C)
-    uint8_t pin; // Pin number (0-7)
-    uint8_t pps_reg; // PPS register value for this pin
+    volatile uint8_t *tris_reg; // Pointer to TRIS register
+    volatile uint8_t *pps_reg;  // Pointer to PPS register
+    uint8_t pin;                // Pin number (0-7)
 } pwm_pin_config_t;
 
 // Macro to concatenate tokens for register naming
@@ -27,29 +27,22 @@ typedef struct {
 // This macro forms the register name for the control register of the specified CCP module
 #define CCP_CON(module) CONCAT(CCP, module, CON)
 
-// Macro to get the TRIS register based on port letter
-// TRIS registers control the direction of pins (input or output)
-// This macro dynamically constructs the TRIS register name for a given port
-#define GET_TRIS_REG(port) CONCAT(TRIS, port, A)
-
-// Macro to get the PPS register address based on port and pin
-// PPS (Peripheral Pin Select) allows mapping of peripherals to different pins
-// This macro forms the PPS register name for a given port and pin
-#define GET_PPS_REG(port, pin) CONCAT(R, port, pin##PPS)
-
-// Macro to set the TRIS register for a specific pin
-// This macro configures the specified pin as an output by clearing the corresponding bit in the
-// TRIS register
-#define SET_TRIS_OUTPUT(port, pin) (GET_TRIS_REG(port) &= ~(1 << (pin)))
-
-// Macro to assign the CCP module to the PPS register
-// This macro assigns the CCP module to a specific pin by writing to the PPS register
-#define ASSIGN_PPS(port, pin, ccp_module) (*GET_PPS_REG(port, pin) = (ccp_module))
-
 // Function prototypes
 w_status_t pwm_init(
     uint8_t ccp_module, pwm_pin_config_t pin_config, uint16_t pwm_period
 ); // Initializes the PWM for a specific CCP module
+
+/**
+ * Example usage:
+ * 
+ * pwm_pin_config_t config;
+ * config.tris_reg = &TRISA;  // Direct register pointer 
+ * config.pps_reg = &RA0PPS;  // Direct register pointer for PPS
+ * config.pin = 0;            // Pin number (0-7)
+ * 
+ * pwm_init(1, config, 255);  // Initialize PWM on CCP1 with period 255
+ */
+
 w_status_t pwm_update_duty_cycle(
     uint8_t ccp_module, uint16_t duty_cycle
 ); // Updates the duty cycle of the specified CCP module

--- a/pic18f26k83/pwm.c
+++ b/pic18f26k83/pwm.c
@@ -1,22 +1,18 @@
 #include "pwm.h"
 #include <xc.h>
 
-// Helper function to configure PPS registers using macros
+// Helper function to configure PPS registers using direct register access
 static w_status_t configure_pps(uint8_t ccp_module, pwm_pin_config_t pin_config) {
-    volatile uint8_t *pps_reg;
-
     // Ensure the CCP module number is within valid range (1-4)
     if (ccp_module < 1 || ccp_module > 4) {
         return W_INVALID_PARAM; // Return error if the module number is out of range
     }
 
-    // Set the pin as output to drive PWM signal
-    // This macro modifies the TRIS register to set the specified pin as an output
-    SET_TRIS_OUTPUT(pin_config.port, pin_config.pin);
+    // Set the pin as output to drive PWM signal directly using the TRIS register
+    *pin_config.tris_reg &= ~(1 << pin_config.pin);
 
-    // Assign the CCP module to the corresponding PPS register
-    // This macro sets up the peripheral pin select to link the CCP module to the desired pin
-    ASSIGN_PPS(pin_config.port, pin_config.pin, ccp_module);
+    // Assign the CCP module to the corresponding PPS register directly
+    *pin_config.pps_reg = ccp_module;
 
     return W_SUCCESS; // Return success status after configuring PPS
 }


### PR DESCRIPTION
Fixed the PWM driver by using direct register pointers for TRIS and PPS configuration, improving type safety and clarity. Update example usage and remove outdated macros for better maintainability.