### PR TITLE
Document i2c.h with doxygen docstring

### DIFF
--- a/include/i2c.h
+++ b/include/i2c.h
@@ -1,3 +1,12 @@
+/**
+ * @file
+ * @brief PIC18 I2C master driver
+ *
+ * This module provides I2C master functionality for the PIC18F26K83 microcontroller.
+ * It supports standard I2C operations including read/write data and register read/write
+ * operations for 8-bit and 16-bit registers.
+ */
+
 #ifndef ROCKETLIB_I2C_H
 #define ROCKETLIB_I2C_H
 
@@ -8,29 +17,101 @@
 #error "C++ is not supported"
 #endif
 
-/*
- * Configuration Constants
+/**
+ * @brief Configuration constants for I2C interface
+ *
  * These define the behavior and timing characteristics of the I2C interface
  */
-#define I2C_POLL_TIMEOUT 2000 // Maximum cycles to wait during I2C operations
-#define I2C_STRETCH_DELAY 100 // Microseconds to delay during clock stretching
-#define I2C_CLOCK_FREQ 100000 // Default I2C clock frequency (100 kHz)
+#define I2C_POLL_TIMEOUT 2000 ///< Maximum cycles to wait during I2C operations
+#define I2C_STRETCH_DELAY 100 ///< Microseconds to delay during clock stretching
+#define I2C_CLOCK_FREQ 100000 ///< Default I2C clock frequency (100 kHz)
 
-/*
- * Initialize I2C controller with specified clock settings
- * clkdiv: Clock divider (0-7) determines I2C frequency:
- *   0 = 100kHz (standard mode)
- *   1 = 50kHz
- *   2 = 25kHz
- *   etc.
+/**
+ * @brief Initialize I2C controller with specified clock settings
+ *
+ * This function initializes the I2C module in master mode with the specified clock divider.
+ * The clock divider determines the I2C bus frequency:
+ * - 0 = 100kHz (standard mode)
+ * - 1 = 50kHz
+ * - 2 = 25kHz
+ * - etc.
+ *
+ * @param clkdiv Clock divider (0-7) that determines I2C frequency
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR if initialization fails
  */
 w_status_t i2c_init(uint8_t clkdiv);
 
+/**
+ * @brief Write data to an I2C device
+ *
+ * This function writes a sequence of bytes to the specified I2C device address.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param data Pointer to the data buffer to write
+ * @param len Number of bytes to write
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_write_data(uint8_t address, const uint8_t *data, uint8_t len);
+
+/**
+ * @brief Read data from an I2C device
+ *
+ * This function reads a sequence of bytes from the specified I2C device address.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param data Pointer to the data buffer to store read data
+ * @param len Number of bytes to read
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_read_data(uint8_t address, uint8_t *data, uint8_t len);
+
+/**
+ * @brief Write an 8-bit value to a register on an I2C device
+ *
+ * This function writes a single 8-bit value to a specific register address on the I2C device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to write to
+ * @param val 8-bit value to write
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_write_reg8(uint8_t address, uint8_t reg, uint8_t val);
+
+/**
+ * @brief Write a 16-bit value to a register on an I2C device
+ *
+ * This function writes a 16-bit value (MSB first) to a specific register address on the I2C device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to write to
+ * @param val 16-bit value to write (MSB first)
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_write_reg16(uint8_t address, uint8_t reg, uint16_t val);
+
+/**
+ * @brief Read an 8-bit value from a register on an I2C device
+ *
+ * This function reads a single 8-bit value from a specific register address on the I2C device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to read from
+ * @param value Pointer to store the read 8-bit value
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_read_reg8(uint8_t address, uint8_t reg, uint8_t *value);
+
+/**
+ * @brief Read a 16-bit value from a register on an I2C device
+ *
+ * This function reads a 16-bit value (MSB first) from a specific register address on the I2C
+ * device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to read from
+ * @param value Pointer to store the read 16-bit value
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_read_reg16(uint8_t address, uint8_t reg, uint16_t *value);
 
 #endif

--- a/pic18f26k83/i2c.c
+++ b/pic18f26k83/i2c.c
@@ -7,15 +7,10 @@
 #define _XTAL_FREQ 16000000
 #endif
 
-/* Private function declarations */
-static void clear_i2c_buffers(void);
-static w_status_t check_i2c_state(void);
-static w_status_t wait_for_idle(void);
-static w_status_t i2c_write(uint8_t address, const uint8_t *data, uint8_t len);
-static w_status_t i2c_read(uint8_t address, uint8_t *data, uint8_t len);
-
-/*
- * Clear I2C buffers and ensure they're in a known state
+/**
+ * @brief Clear I2C buffers and ensure they're in a known state
+ *
+ * This function clears the I2C buffer flags and flushes any pending data from the receive buffer.
  */
 static void clear_i2c_buffers(void) {
 	// Clear the buffer flag and flush any pending data
@@ -25,9 +20,14 @@ static void clear_i2c_buffers(void) {
 	}
 }
 
-/*
- * Check the current state of the I2C module
- * Verifies module is enabled and no errors are present
+/**
+ * @brief Check the current state of the I2C module
+ *
+ * This function verifies that the I2C module is enabled and checks for any error conditions.
+ * If errors are detected, they are cleared before returning.
+ *
+ * @return w_status_t Returns W_SUCCESS if module is ready, W_IO_ERROR if module is disabled or
+ * errors detected
  */
 static w_status_t check_i2c_state(void) {
 	if (!I2C1CON0bits.EN) {
@@ -46,9 +46,13 @@ static w_status_t check_i2c_state(void) {
 	return W_SUCCESS;
 }
 
-/*
- * Wait for the I2C bus to become idle
- * Monitors the Bus Free bit with timeout protection
+/**
+ * @brief Wait for the I2C bus to become idle
+ *
+ * This function monitors the Bus Free bit with timeout protection to ensure the I2C bus
+ * is available before starting a new transaction.
+ *
+ * @return w_status_t Returns W_SUCCESS when bus is idle, W_IO_TIMEOUT if timeout occurs
  */
 static w_status_t wait_for_idle(void) {
 	unsigned int timeout = 0;
@@ -60,6 +64,19 @@ static w_status_t wait_for_idle(void) {
 	return W_SUCCESS;
 }
 
+/**
+ * @brief Initialize I2C controller with specified clock settings
+ *
+ * This function initializes the I2C module in master mode with the specified clock divider.
+ * The clock divider determines the I2C bus frequency:
+ * - 0 = 100kHz (standard mode)
+ * - 1 = 50kHz
+ * - 2 = 25kHz
+ * - etc.
+ *
+ * @param clkdiv Clock divider (0-7) that determines I2C frequency
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR if initialization fails
+ */
 w_status_t i2c_init(uint8_t clkdiv) {
 	// Disable module for configuration
 	I2C1CON0bits.EN = 0;
@@ -93,6 +110,17 @@ w_status_t i2c_init(uint8_t clkdiv) {
 	return wait_for_idle();
 }
 
+/**
+ * @brief Internal function to write data to an I2C device
+ *
+ * This is the low-level write function that handles the actual I2C transaction.
+ * It verifies bus state, sends the address and data bytes, and waits for completion.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param data Pointer to the data buffer to write
+ * @param len Number of bytes to write
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 static w_status_t i2c_write(uint8_t address, const uint8_t *data, uint8_t len) {
 	// Verify bus state and prepare for transfer
 	w_status_t status = check_i2c_state();
@@ -151,6 +179,17 @@ static w_status_t i2c_write(uint8_t address, const uint8_t *data, uint8_t len) {
 	return W_SUCCESS;
 }
 
+/**
+ * @brief Internal function to read data from an I2C device
+ *
+ * This is the low-level read function that handles the actual I2C transaction.
+ * It verifies bus state, sends the read address, receives data bytes, and waits for completion.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param data Pointer to the data buffer to store read data
+ * @param len Number of bytes to read
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 static w_status_t i2c_read(uint8_t address, uint8_t *data, uint8_t len) {
 	// Verify bus state and prepare for transfer
 	w_status_t status = check_i2c_state();
@@ -207,23 +246,59 @@ static w_status_t i2c_read(uint8_t address, uint8_t *data, uint8_t len) {
 	return W_SUCCESS;
 }
 
-/*
- * Public interface functions
- * These provide the high-level API for I2C communication
+/**
+ * @brief Write data to an I2C device
+ *
+ * This function writes a sequence of bytes to the specified I2C device address.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param data Pointer to the data buffer to write
+ * @param len Number of bytes to write
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
  */
 w_status_t i2c_write_data(uint8_t address, const uint8_t *data, uint8_t len) {
 	return i2c_write(address, data, len);
 }
 
+/**
+ * @brief Read data from an I2C device
+ *
+ * This function reads a sequence of bytes from the specified I2C device address.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param data Pointer to the data buffer to store read data
+ * @param len Number of bytes to read
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_read_data(uint8_t address, uint8_t *data, uint8_t len) {
 	return i2c_read(address, data, len);
 }
 
+/**
+ * @brief Write an 8-bit value to a register on an I2C device
+ *
+ * This function writes a single 8-bit value to a specific register address on the I2C device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to write to
+ * @param val 8-bit value to write
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_write_reg8(uint8_t address, uint8_t reg, uint8_t val) {
 	uint8_t data[2] = {reg, val};
 	return i2c_write(address, data, 2);
 }
 
+/**
+ * @brief Write a 16-bit value to a register on an I2C device
+ *
+ * This function writes a 16-bit value (MSB first) to a specific register address on the I2C device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to write to
+ * @param val 16-bit value to write (MSB first)
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_write_reg16(uint8_t address, uint8_t reg, uint16_t val) {
 	uint8_t data[3] = {
 		reg,
@@ -233,6 +308,16 @@ w_status_t i2c_write_reg16(uint8_t address, uint8_t reg, uint16_t val) {
 	return i2c_write(address, data, 3);
 }
 
+/**
+ * @brief Read an 8-bit value from a register on an I2C device
+ *
+ * This function reads a single 8-bit value from a specific register address on the I2C device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to read from
+ * @param value Pointer to store the read 8-bit value
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_read_reg8(uint8_t address, uint8_t reg, uint8_t *value) {
 	// Write register address
 	w_status_t status = i2c_write(address, &reg, 1);
@@ -244,6 +329,17 @@ w_status_t i2c_read_reg8(uint8_t address, uint8_t reg, uint8_t *value) {
 	return i2c_read(address, value, 1);
 }
 
+/**
+ * @brief Read a 16-bit value from a register on an I2C device
+ *
+ * This function reads a 16-bit value (MSB first) from a specific register address on the I2C
+ * device.
+ *
+ * @param address I2C device address (7-bit, will be shifted left by 1)
+ * @param reg Register address to read from
+ * @param value Pointer to store the read 16-bit value
+ * @return w_status_t Returns W_SUCCESS on success, W_IO_ERROR on error, W_IO_TIMEOUT on timeout
+ */
 w_status_t i2c_read_reg16(uint8_t address, uint8_t reg, uint16_t *value) {
 	// Write register address
 	w_status_t status = i2c_write(address, &reg, 1);


### PR DESCRIPTION
Adds comprehensive doxygen documentation to i2c.h header file.

- Adds file-level documentation describing the I2C module
- Documents all functions with @brief, @param, and @return tags
- Includes detailed descriptions of I2C clock frequency configuration

Closes #54